### PR TITLE
Исправление для передачи параметра when при создании CInlineValidator

### DIFF
--- a/framework/validators/CValidator.php
+++ b/framework/validators/CValidator.php
@@ -184,6 +184,8 @@ abstract class CValidator extends CComponent
 			$validator->params=$params;
 			if(isset($params['skipOnError']))
 				$validator->skipOnError=$params['skipOnError'];
+			if(isset($params['when']))
+				$validator->when=$params['when'];
 		}
 		else
 		{


### PR DESCRIPTION
Иначе условие when не отрабатывает при использовании кастомных
валидаторов
